### PR TITLE
Support classy-node in place of classy-api-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bugsnag": "^2.1.3",
     "bunyan": "^1.8.12",
     "classy-api-client": "latest",
+    "classy-node": "^2.5.7",
     "lodash": "^4.17.5",
     "nodecredstash": "^2.0.2",
     "regenerator-runtime": "^0.11.1",

--- a/src/DataSources/Clients.js
+++ b/src/DataSources/Clients.js
@@ -20,13 +20,21 @@ class ClientDataSource {
     }
 
     if (await config.get('api')) {
-      this.clients.apiClient = Promise.promisifyAll(require('classy-api-client')({
-        clientId: await config.get('APIV2_CLIENT_ID'),
-        clientSecret: await config.get('APIV2_CLIENT_SECRET'),
-        timeout: await config.get('api.timeout'),
-        oauthUrl: await config.get('api.oauthUrl'),
-        apiUrl: await config.get('api.apiUrl')
-      }));
+      if (await config.get('api.clientType') === 'classy-node') {
+        const Classy = require('classy-node');
+        this.clients.apiClient = new Classy({
+          clientId: await config.get('APIV2_CLIENT_ID'),
+          clientSecret: await config.get('APIV2_CLIENT_SECRET')
+        });
+      } else {
+        this.clients.apiClient = Promise.promisifyAll(require('classy-api-client')({
+          clientId: await config.get('APIV2_CLIENT_ID'),
+          clientSecret: await config.get('APIV2_CLIENT_SECRET'),
+          timeout: await config.get('api.timeout'),
+          oauthUrl: await config.get('api.oauthUrl'),
+          apiUrl: await config.get('api.apiUrl')
+        }));
+      }
     }
   }
 


### PR DESCRIPTION
If you provide "api.clientType" as "classy-node" in environment.json / env.yml, vend prebuilt classy-node client instead of classy-api-client.